### PR TITLE
Add command to copy previous commit for clipboard

### DIFF
--- a/git/copy-previous-commit-to-clipboard.md
+++ b/git/copy-previous-commit-to-clipboard.md
@@ -8,4 +8,6 @@ The following code snippet copies your last commit message to clipboard, so you 
 git log -1 --pretty=%B | pbcopy
 ```
 
+This command works beautifully on MacOS. If `pbcopy` isn't available on your operating system, you may need to tweak the snippet slightly to work with your system clipboard.
+
 Source: https://coderwall.com/p/kdhlcg/copy-last-git-commit-message-to-clipboard-in-osx


### PR DESCRIPTION
Adding helpful one-liner that copies your previous git commit message to
clipboard, so it can be easily re-used in subsequent commit(s)