### PR TITLE
Adds transient-attributes.md and add-with-patch.md

### DIFF
--- a/factory_bot/transient-attributes.md
+++ b/factory_bot/transient-attributes.md
@@ -1,0 +1,29 @@
+## Transient Arguments in FactoryBot
+
+When defining a factory, you can specify extra "transient" arguments to be used as options when creating.
+
+For example, when creating a recipe, you could add a `salty` option:
+
+```ruby
+FactoryBot.define do
+  factory :recipe, class: Recipe do
+    title "Onion Soup"
+    description "an old French classic"
+    total_time "4 hours"
+
+    transient do
+      salty { true }
+
+      after(:create) do |recipe, evaluator|
+        recipe.update_attribute(:title, "Salty " + recipe.title)
+      end
+    end
+  end
+end
+
+create(:recipe, salty: true)
+=> #<Recipe id: 1, title: "Salty Onion Soup", description: "an old French classic", total_time: "4 hours", created_at: "2019-03-19 04:13:20", updated_at: "2019-03-19 04:13:20">
+```
+
+You can also use transient arguments in the same way with Traits:
+[https://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md#Traits](https://www.rubydoc.info/gems/factory_bot/file/GETTING_STARTED.md#Traits)

--- a/git/add-with-patch.md
+++ b/git/add-with-patch.md
@@ -1,0 +1,12 @@
+## Using the --patch option with git-add
+
+If you ever find youself in a situation when you're about to commit but there are some changes you'd rather leave for a later commit, you can use --patch or -p to pick and choose the diffs or "hunks" that you want to stage:
+
+`git add -p`
+
+It will cycle through each hunk and ask if you want to stage it or not (along with some other options, too):
+```
+Stage this hunk [y,n,q,a,d,e,?]?
+```
+
+[https://git-scm.com/docs/git-add](https://git-scm.com/docs/git-add)


### PR DESCRIPTION
Adds two short articles explaining how to use `git add` with the `--patch` option and how to use FactorBot's `transient` attributes.