### PR TITLE
Update Git commit copy command

### DIFF
--- a/git/copy-previous-commit-to-clipboard.md
+++ b/git/copy-previous-commit-to-clipboard.md
@@ -5,7 +5,7 @@ Ever find yourself committing a change that’s almost *exactly* the same as you
 The following code snippet copies your last commit message to clipboard, so you can paste it a second time, tweak slightly, and commit :heart:
 
 ```ruby
-git log -1 --pretty=%B | pbcopy
+git log -1 --pretty=%H | pbcopy
 ```
 
 This command works beautifully on MacOS. If `pbcopy` isn't available on your operating system, you may need to tweak the snippet slightly to work with your system clipboard.


### PR DESCRIPTION
It seem you need to use %H instead of %B, at least on git 2.37.3